### PR TITLE
Remove broken link in android docs

### DIFF
--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -1,7 +1,6 @@
 ## Android Setup
 
 - [Plugin Installation and Configuration](#plugin-installation-and-configuration)
-- [Code Signing setup](#code-signing-setup)
 
 ### Plugin Installation and Configuration
 


### PR DESCRIPTION
This link to code signing is broken because code signing is not a top level item, it is a step under install. The ios docs also have a section on code signing and does not have a link at the top so I thought that was probably the intended behavior.