### PR TITLE
fix: missing homepage define in package.json@v8.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "typings": "typings/react-native-code-push.d.ts",
   "author": "Louis Lagrange <lagrange.louis@gmail.com> (https://github.com/Minishlink)",
   "license": "MIT",
+  "homepage": "https://appzung.com",
   "scripts": {
     "clean": "shx rm -rf bin",
     "setup": "npm install --quiet --no-progress",


### PR DESCRIPTION
Hi AppZung team, @mahcloud, @Minishlink, @maitrerobert, @AmauryLiet 

I hope this PR finds you well.

We encountered an error while running pod install due to the CodePush pod failing validation:

`
ERROR | attributes: Missing required attribute `homepage`.87
`

## Proposed Solution

- Add the missing "homepage" field to package.json.

- Bump the package version to 8.3.3 for publishing and consumption.

This fix is necessary to allow successful pod install execution and maintain compatibility with the React Native iOS build pipeline.

Thanks in advance for reviewing this update! 🙏

Best regards,